### PR TITLE
Onboarding fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bsv/brc100-ui-react-components",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bsv/brc100-ui-react-components",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "Open BSV License",
       "dependencies": {
         "@bsv/message-box-client": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bsv/brc100-ui-react-components",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": false,
   "publishConfig": {
     "access": "public"

--- a/src/components/MetanetApp.tsx
+++ b/src/components/MetanetApp.tsx
@@ -13,6 +13,8 @@ interface MetanetAppProps extends RouteComponentProps {
   appName?: string
   onClick?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
   clickable?: boolean
+  variant?: 'default' | 'plain'
+  hideLabel?: boolean
 }
 
 const MetanetApp: React.FC<MetanetAppProps> = ({
@@ -22,6 +24,8 @@ const MetanetApp: React.FC<MetanetAppProps> = ({
   history,
   onClick,
   clickable = true,
+  variant = 'default',
+  hideLabel = false,
 }) => {
   const theme = useTheme()
 
@@ -53,82 +57,55 @@ const MetanetApp: React.FC<MetanetAppProps> = ({
     }
   }
 
-  return (
-    <Card
-      sx={{
-        cursor: clickable ? 'pointer' : 'default',
-        boxShadow: 'none',
-        textAlign: 'center',
-        display: 'flex',
-        flexDirection: 'column', // Stack items vertically
-        height: '100%', // Fill the container height
-        width: '100%',
-        // Responsive card width
-        maxWidth: {
-          xs: '100px', // Smaller on mobile
-          sm: '110px', // Medium on tablets
-          md: '130px', // Larger on desktop
-          lg: '140px', // Even larger on big screens
-          xl: '150px', // Extra large screens
-        },
-        justifyContent: 'center',
-        transition: 'background 0.3s ease',
-        backgroundColor: 'transparent',
-        backgroundImage: 'none',
-        margin: '0 auto', // Center the card
-        '&:hover': {
-          backgroundColor: (theme as any).palette.action?.hover || 'rgba(0, 0, 0, 0.04)'
-        },
-      }}
-      onClick={handleClick}
-    >
-      <CardContent>
-        <div>
-          <Box
-            sx={{
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-              paddingTop: '0.4em',
-              // Responsive container sizing
-              width: {
-                xs: '48px',  // Smaller on mobile
-                sm: '56px',  // Medium on tablets
-                md: '72px',  // Larger on desktop
-                lg: '80px',  // Even larger on big screens
-                xl: '84px',  // Extra large screens
-              },
-              height: {
-                xs: '48px',
-                sm: '56px',
-                md: '72px',
-                lg: '80px',
-                xl: '84px',
-              },
-              maxWidth: '96px',  // Increased maximum size
-              maxHeight: '96px',
-              margin: '0 auto',
-            }}
-          >
-            <Img
-              src={iconImageUrl}
-              alt={displayName}
-              style={{
-                objectFit: 'contain',
-                width: '100%',
-                height: '100%',
-              }}
-            />
-          </Box>
-        </div>
-        {/*
-          TODO: Remove references to webkit once browsers mature to a good level
-        */}
+  const content = (
+    <>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          // Responsive container sizing
+          width: {
+            xs: '48px',  // Smaller on mobile
+            sm: '56px',  // Medium on tablets
+            md: '72px',  // Larger on desktop
+            lg: '80px',  // Even larger on big screens
+            xl: '84px',  // Extra large screens
+          },
+          height: {
+            xs: '48px',
+            sm: '56px',
+            md: '72px',
+            lg: '80px',
+            xl: '84px',
+          },
+          maxWidth: '96px',
+          maxHeight: '96px',
+          margin: '0 auto',
+        }}
+      >
+        <Img
+          src={iconImageUrl}
+          alt={displayName}
+          style={{
+            objectFit: 'contain',
+            width: '100%',
+            height: '100%',
+            borderRadius: '8px'
+          }}
+          onError={(e) => {
+            try {
+              (e.target as HTMLImageElement).src = 'https://metanetapps.com/favicon.ico'
+            } catch {}
+          }}
+        />
+      </Box>
+      {!hideLabel && (
         <Typography
           variant="body2"
           sx={{
             color: (theme as any).palette.text?.primary || 'inherit',
-            paddingTop: '0.4em',
+            mt: 0.5,
             display: '-webkit-box',
             overflow: 'hidden',
             WebkitBoxOrient: 'vertical',
@@ -144,8 +121,70 @@ const MetanetApp: React.FC<MetanetAppProps> = ({
         >
           {displayName}
         </Typography>
-      </CardContent>
-    </Card>
+      )}
+    </>
+  )
+
+  return (
+    variant === 'plain' ? (
+      <Box
+        sx={{
+          cursor: clickable ? 'pointer' : 'default',
+          textAlign: 'center',
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100%',
+          width: '100%',
+          maxWidth: {
+            xs: '100px',
+            sm: '110px',
+            md: '130px',
+            lg: '140px',
+            xl: '150px',
+          },
+          justifyContent: 'center',
+          alignItems: 'center',
+          background: 'transparent',
+          margin: '0 auto',
+        }}
+        onClick={handleClick}
+      >
+        {content}
+      </Box>
+    ) : (
+      <Card
+        sx={{
+          cursor: clickable ? 'pointer' : 'default',
+          boxShadow: 'none',
+          textAlign: 'center',
+          display: 'flex',
+          flexDirection: 'column', // Stack items vertically
+          height: '100%', // Fill the container height
+          width: '100%',
+          // Responsive card width
+          maxWidth: {
+            xs: '100px', // Smaller on mobile
+            sm: '110px', // Medium on tablets
+            md: '130px', // Larger on desktop
+            lg: '140px', // Even larger on big screens
+            xl: '150px', // Extra large screens
+          },
+          justifyContent: 'center',
+          transition: 'background 0.3s ease',
+          backgroundColor: 'transparent',
+          backgroundImage: 'none',
+          margin: '0 auto', // Center the card
+          '&:hover': {
+            backgroundColor: (theme as any).palette.action?.hover || 'rgba(0, 0, 0, 0.04)'
+          },
+        }}
+        onClick={handleClick}
+      >
+        <CardContent sx={{ py: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
+          {content}
+        </CardContent>
+      </Card>
+    )
   )
 }
 

--- a/src/components/PageHeader/index.tsx
+++ b/src/components/PageHeader/index.tsx
@@ -24,6 +24,11 @@ interface PageHeaderProps {
   showButton?: boolean
   showBackButton?: boolean
   onBackClick?: () => void
+  // Optional secondary action button
+  showSecondaryButton?: boolean
+  secondaryButtonTitle?: string
+  secondaryButtonIcon?: React.ReactNode
+  onSecondaryClick?: () => void
 }
 
 const PageHeader: FC<PageHeaderProps> = ({
@@ -37,14 +42,18 @@ const PageHeader: FC<PageHeaderProps> = ({
   showButton = true,
   showBackButton = true,
   onBackClick,
+  showSecondaryButton = false,
+  secondaryButtonTitle,
+  secondaryButtonIcon,
+  onSecondaryClick,
 }) => {
   const classes = useStyles()
 
   return (
     <div>
       <div className={(classes as any).top_grid}>
-        {showBackButton && (
-          <div>
+        <div>
+          {showBackButton && (
             <IconButton
               className={(classes as any).back_button}
               onClick={onBackClick || (() => history.go(-1))}
@@ -52,8 +61,8 @@ const PageHeader: FC<PageHeaderProps> = ({
             >
               <ArrowBack />
             </IconButton>
-          </div>
-        )}
+          )}
+        </div>
         <div>
           <Img
             className={(classes as any).app_icon}
@@ -73,6 +82,19 @@ const PageHeader: FC<PageHeaderProps> = ({
           )}
         </div>
         <div>
+          {showSecondaryButton && secondaryButtonTitle && (
+            <Button
+              className={(classes as any).action_button}
+              variant="outlined"
+              color="primary"
+              size="large"
+              startIcon={secondaryButtonIcon}
+              onClick={onSecondaryClick}
+              sx={{ mr: showButton ? 1 : 0 }}
+            >
+              {secondaryButtonTitle}
+            </Button>
+          )}
           {showButton && (
             <Button
               className={(classes as any).action_button}

--- a/src/navigation/Menu.tsx
+++ b/src/navigation/Menu.tsx
@@ -369,6 +369,8 @@ export default function Menu({ menuOpen, setMenuOpen, menuRef }: MenuProps) {
     refreshProfiles()
   }, [refreshProfiles])
 
+  const isAppsSelected = history.location.pathname === '/dashboard/apps' || history.location.pathname === '/dashboard/recent-apps'
+
   return (
     <Drawer
       anchor='left'
@@ -530,17 +532,17 @@ export default function Menu({ menuOpen, setMenuOpen, menuRef }: MenuProps) {
         <List component="nav" sx={{ mb: 2 }}>
           <ListItemButton
             onClick={() => navigation.push('/dashboard/apps')}
-            selected={history.location.pathname === '/dashboard/apps'}
-            sx={menuItemStyle(history.location.pathname === '/dashboard/apps')}
+            selected={isAppsSelected}
+            sx={menuItemStyle(isAppsSelected)}
           >
-            <ListItemIcon sx={{ minWidth: 40, color: history.location.pathname === '/dashboard/apps' ? 'primary.main' : 'inherit' }}>
+            <ListItemIcon sx={{ minWidth: 40, color: isAppsSelected ? 'primary.main' : 'inherit' }}>
               <BrowseIcon />
             </ListItemIcon>
             <ListItemText
               primary={
                 <Typography
                   variant="body1"
-                  fontWeight={history.location.pathname === '/dashboard/apps' ? 600 : 400}
+                  fontWeight={isAppsSelected ? 600 : 400}
                 >
                   Apps
                 </Typography>

--- a/src/navigation/Menu.tsx
+++ b/src/navigation/Menu.tsx
@@ -120,7 +120,6 @@ export default function Menu({ menuOpen, setMenuOpen, menuRef }: MenuProps) {
 
   useEffect(() => {
     let cancelled = false
-    debugger
     const run = async () => {
       if (!managers?.walletManager || !activeProfile?.name) return
       const cacheKey = `funds_${activeProfile.name}`

--- a/src/pages/Dashboard/AppCatalog/index.tsx
+++ b/src/pages/Dashboard/AppCatalog/index.tsx
@@ -3,7 +3,6 @@ import {
   Typography,
   Container,
   TextField,
-  LinearProgress,
   Box,
   Chip,
   Card,
@@ -11,10 +10,6 @@ import {
   IconButton,
   FormControl,
   Button,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
   Slide,
 } from '@mui/material'
 import Grid2 from '@mui/material/Grid2'
@@ -65,10 +60,6 @@ const AppCatalog: React.FC = () => {
   const [lastUpdated, setLastUpdated] = useState<number | null>(null)
   const [isRefreshing, setIsRefreshing] = useState<boolean>(false)
   const inputRef = useRef<HTMLInputElement>(null)
-  type RedirectAppInfo = { name: string; Originator: string; custom_message?: string }
-
-  const [redirectOpen, setRedirectOpen] = useState(false)
-  const [redirectApp, setRedirectApp] = useState<RedirectAppInfo | null>(null)
 
 
   // Configuration for Fuse
@@ -209,50 +200,7 @@ const AppCatalog: React.FC = () => {
   // Load apps on mount
   useEffect(() => {
     loadCatalogApps()
-    try {
-      const s = sessionStorage.getItem('appinfo')
-      if (s) {
-        const parsed = JSON.parse(s) as RedirectAppInfo
-        setRedirectApp(parsed)
-        setRedirectOpen(true)
-      }
-    } catch {
-    }
   }, [])
-
-  const redirectDomain = useMemo(() => {
-    if (!redirectApp?.Originator) return ''
-    try {
-      return new URL(redirectApp.Originator).host
-    } catch {
-      return redirectApp.Originator
-    }
-  }, [redirectApp])
-  
-  // continue handler
-  const handleRedirectContinue = useCallback(() => {
-    const url = redirectApp?.Originator
-    // Close any open modals/dialogs immediately
-    setRedirectOpen(false)
-    setOpenModal(false)
-    try { sessionStorage.removeItem('appinfo') } catch {}
-
-    if (!url) return
-
-    // Defer opening the URL until after the dialog has unmounted to avoid any overlay/focus issues
-    setTimeout(() => {
-      try {
-        openUrl(url)
-      } catch {
-        toast.error('Failed to open app')
-      }
-    }, 0)
-  }, [redirectApp])
-  
-  // optional: nice slide-up transition
-  const RedirectTransition = forwardRef(function RedirectTransition(props: any, ref: any) {
-    return <Slide direction="up" ref={ref} {...props} />
-  })
   
   const handleRefreshClick = async () => {
     setIsRefreshing(true)
@@ -263,99 +211,6 @@ const AppCatalog: React.FC = () => {
 
   return (
     <div className={classes.root}>
-      {redirectOpen && (
-        <Dialog
-          open
-          onClose={() => { try { sessionStorage.removeItem('appinfo') } catch {}; setRedirectOpen(false) }}
-          fullWidth
-          maxWidth="sm"
-          TransitionComponent={RedirectTransition}
-          disableEnforceFocus
-          disableScrollLock
-        >
-  <DialogTitle sx={{ fontWeight: 700 }}>
-    Continue to {redirectApp?.name}?
-  </DialogTitle>
-
-  <DialogContent dividers>
-    <Box sx={{ display: 'flex', gap: 2, alignItems: 'center', mb: 1 }}>
-      {/* Optional: show the app tile if you want */}
-      <Box
-        sx={{
-          width: 64,
-          height: 64,
-          borderRadius: 2,
-          overflow: 'hidden',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          bgcolor: 'action.hover',
-          flexShrink: 0,
-        }}
-      >
-        {/* If you have MetanetApp, you can use it here instead of this box */}
-        {redirectDomain ? (
-          <img
-            src={`https://${redirectDomain}/favicon.ico`}
-            alt={`${redirectApp?.name} icon`}
-            style={{ maxWidth: '100%', maxHeight: '100%' }}
-            onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none' }}
-          />
-        ) : null}
-      </Box>
-
-      <Box sx={{ minWidth: 0 }}>
-        <Typography
-          sx={{
-            fontWeight: 700,
-            fontSize: '1.1rem',
-            whiteSpace: 'nowrap',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-          }}
-        >
-          {redirectApp?.name}
-        </Typography>
-
-        {redirectApp?.custom_message && (
-          <Typography
-            variant="body2"
-            color="text.secondary"
-            sx={{
-              mt: 0.5,
-              display: '-webkit-box',
-              WebkitLineClamp: 3,
-              WebkitBoxOrient: 'vertical',
-              overflow: 'hidden',
-            }}
-          >
-            {redirectApp.custom_message}
-          </Typography>
-        )}
-
-        {redirectDomain && (
-          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
-            {redirectDomain}
-          </Typography>
-        )}
-      </Box>
-    </Box>
-  </DialogContent>
-
-  <DialogActions sx={{ px: 3, py: 2 }}>
-    <Button onClick={() => { try { sessionStorage.removeItem('appinfo') } catch {}; setRedirectOpen(false) }} color="inherit">
-      Cancel
-    </Button>
-    <Button
-      onClick={handleRedirectContinue}
-      variant="contained"
-      endIcon={<OpenInNewIcon />}
-    >
-      Continue
-    </Button>
-  </DialogActions>
-</Dialog>
-      )}
       {currentView === 'list' && (
         <>
           <PageHeader

--- a/src/pages/Dashboard/AppCatalog/index.tsx
+++ b/src/pages/Dashboard/AppCatalog/index.tsx
@@ -1,16 +1,16 @@
-import React, { useState, useEffect, useRef, forwardRef, useMemo, useCallback } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import {
   Typography,
   Container,
   TextField,
+  LinearProgress,
   Box,
   Chip,
   Card,
   Modal,
   IconButton,
   FormControl,
-  Button,
-  Slide,
+  Button
 } from '@mui/material'
 import Grid2 from '@mui/material/Grid2'
 import { makeStyles } from '@mui/styles'
@@ -23,9 +23,10 @@ import RefreshIcon from '@mui/icons-material/Refresh'
 import Fuse from 'fuse.js'
 import { useHistory } from 'react-router-dom'
 import { Img } from '@bsv/uhrp-react'
+
 import PageHeader from '../../../components/PageHeader'
 import { openUrl } from '../../../utils/openUrl'
-import { toast } from 'react-toastify'
+
 import { AppCatalog as AppCatalogAPI } from 'metanet-apps'
 import type { PublishedApp } from 'metanet-apps/src/types'
 import CounterpartyChip from '../../../components/CounterpartyChip'
@@ -59,8 +60,8 @@ const AppCatalog: React.FC = () => {
   const [isExpanded, setIsExpanded] = useState<boolean>(false)
   const [lastUpdated, setLastUpdated] = useState<number | null>(null)
   const [isRefreshing, setIsRefreshing] = useState<boolean>(false)
-  const inputRef = useRef<HTMLInputElement>(null)
 
+  const inputRef = useRef<HTMLInputElement>(null)
 
   // Configuration for Fuse
   const options = {
@@ -201,7 +202,7 @@ const AppCatalog: React.FC = () => {
   useEffect(() => {
     loadCatalogApps()
   }, [])
-  
+
   const handleRefreshClick = async () => {
     setIsRefreshing(true)
     const fresh = await fetchCatalog()

--- a/src/pages/Dashboard/AppCatalog/index.tsx
+++ b/src/pages/Dashboard/AppCatalog/index.tsx
@@ -16,6 +16,7 @@ import { makeStyles } from '@mui/styles'
 import AddIcon from '@mui/icons-material/Add';
 import SearchIcon from '@mui/icons-material/Search'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+import HistoryIcon from '@mui/icons-material/History'
 import CloseIcon from '@mui/icons-material/Close'
 import Fuse from 'fuse.js'
 import { useHistory } from 'react-router-dom'
@@ -129,7 +130,7 @@ const AppCatalog: React.FC = () => {
 
   // Handle back navigation from catalog to apps page
   const handleBackToApps = () => {
-    history.push('/dashboard/apps')
+    history.push('/dashboard/recent-apps')
   }
 
   const handleNavigateToApp = () => {
@@ -161,8 +162,12 @@ const AppCatalog: React.FC = () => {
               openUrl('https://metanetapps.com')
             }}
             history={history}
-            showBackButton={true}
+            showBackButton={false}
             showButton={true}
+            showSecondaryButton={true}
+            secondaryButtonTitle="Recent Apps"
+            secondaryButtonIcon={<HistoryIcon />}
+            onSecondaryClick={handleBackToApps}
             onBackClick={handleBackToApps}
           />
 

--- a/src/pages/Dashboard/Apps/index.tsx
+++ b/src/pages/Dashboard/Apps/index.tsx
@@ -24,6 +24,7 @@ import PushPinIcon from '@mui/icons-material/PushPin'
 import PushPinOutlinedIcon from '@mui/icons-material/PushPinOutlined'
 import Fuse from 'fuse.js'
 import { useHistory } from 'react-router-dom'
+import PageHeader from '../../../components/PageHeader'
 
 import style from './style'
 import MetanetApp from '../../../components/MetanetApp'
@@ -131,7 +132,10 @@ const Apps: React.FC = () => {
     }
   }
   const handleViewCatalog = () => {
-    history.push('/dashboard/app-catalog')
+    history.push('/dashboard/apps')
+  }
+  const handleBackToCatalog = () => {
+    history.push('/dashboard/apps')
   }
 
   // On mount, load the apps & recent apps
@@ -197,31 +201,24 @@ const Apps: React.FC = () => {
 
   return (
     <div className={classes.apps_view}>
-      <Container
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center'
-        }}
-      >
-        <Typography variant="h1" color="textPrimary" sx={{ mb: 2 }}>
-          Apps
-        </Typography>
-        <Typography variant="body1" color="textSecondary" sx={{ mb: 2 }}>
-          Browse and manage your application permissions.
-        </Typography>
+      <PageHeader
+        title="Recent Apps"
+        subheading={
+          <Typography variant="body2" color="textSecondary">
+            Apps you've used recently and pinned
+          </Typography>
+        }
+        icon="https://metanetapps.com/favicon.ico"
+        buttonTitle="Open App Catalog"
+        buttonIcon={<ExploreIcon />}
+        onClick={handleViewCatalog}
+        history={history as any}
+        showButton={true}
+        showBackButton={true}
+        onBackClick={handleBackToCatalog}
+      />
 
-        {/* View App Catalog Button */}
-        <Button
-          variant="outlined"
-          startIcon={<ExploreIcon />}
-          onClick={handleViewCatalog}
-          sx={{ mb: 2 }}
-        >
-          View App Catalog
-        </Button>
-
+      <Container>
         <FormControl sx={{
           width: '100%',
           display: 'flex',

--- a/src/pages/Dashboard/Apps/index.tsx
+++ b/src/pages/Dashboard/Apps/index.tsx
@@ -24,7 +24,6 @@ import PushPinIcon from '@mui/icons-material/PushPin'
 import PushPinOutlinedIcon from '@mui/icons-material/PushPinOutlined'
 import Fuse from 'fuse.js'
 import { useHistory } from 'react-router-dom'
-import PageHeader from '../../../components/PageHeader'
 
 import style from './style'
 import MetanetApp from '../../../components/MetanetApp'
@@ -132,10 +131,7 @@ const Apps: React.FC = () => {
     }
   }
   const handleViewCatalog = () => {
-    history.push('/dashboard/apps')
-  }
-  const handleBackToCatalog = () => {
-    history.push('/dashboard/apps')
+    history.push('/dashboard/app-catalog')
   }
 
   // On mount, load the apps & recent apps
@@ -201,24 +197,31 @@ const Apps: React.FC = () => {
 
   return (
     <div className={classes.apps_view}>
-      <PageHeader
-        title="Recent Apps"
-        subheading={
-          <Typography variant="body2" color="textSecondary">
-            Apps you've used recently and pinned
-          </Typography>
-        }
-        icon="https://metanetapps.com/favicon.ico"
-        buttonTitle="Open App Catalog"
-        buttonIcon={<ExploreIcon />}
-        onClick={handleViewCatalog}
-        history={history as any}
-        showButton={true}
-        showBackButton={true}
-        onBackClick={handleBackToCatalog}
-      />
+      <Container
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center'
+        }}
+      >
+        <Typography variant="h1" color="textPrimary" sx={{ mb: 2 }}>
+          Apps
+        </Typography>
+        <Typography variant="body1" color="textSecondary" sx={{ mb: 2 }}>
+          Browse and manage your application permissions.
+        </Typography>
 
-      <Container>
+        {/* View App Catalog Button */}
+        <Button
+          variant="outlined"
+          startIcon={<ExploreIcon />}
+          onClick={handleViewCatalog}
+          sx={{ mb: 2 }}
+        >
+          View App Catalog
+        </Button>
+
         <FormControl sx={{
           width: '100%',
           display: 'flex',

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -115,11 +115,12 @@ export default function Dashboard() {
           />
           <Route
             path='/dashboard/apps'
-            component={Apps}
-          />
-          <Route
-            path='/dashboard/app-catalog'
             component={AppCatalog}
+          />
+          <Redirect from='/dashboard/app-catalog' to='/dashboard/apps' />
+          <Route
+            path='/dashboard/recent-apps'
+            component={Apps}
           />
           <Route
             path='/dashboard/app' // Consider if this needs /:app parameter

--- a/src/pages/Greeter/index.tsx
+++ b/src/pages/Greeter/index.tsx
@@ -474,12 +474,25 @@ const Greeter: React.FC<any> = ({ history }) => {
               sx={{
                 width: 120,
                 height: 120,
-                bgcolor: 'rgba(255,255,255,0.2)',
-                border: '1px solid rgba(255,255,255,0.4)',
                 borderRadius: 1,
-                flex: '0 0 auto'
+                flex: '0 0 auto',
+                overflow: 'hidden',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                bgcolor: 'rgba(255,255,255,0.2)',
+                border: '1px solid rgba(255,255,255,0.4)'
               }}
-            />
+            >
+              {(appInfo as any)?.Originator || (appInfo as any)?.redirected_from ? (
+                <Box
+                  component="img"
+                  src={`${(((appInfo as any)?.Originator || (appInfo as any)?.redirected_from) as string).replace(/\/$/, '')}/favicon.ico`}
+                  alt={(appInfo as any)?.name ? `${(appInfo as any).name} icon` : 'App icon'}
+                  sx={{ width: '100%', height: '100%', objectFit: 'contain', p: 1 }}
+                />
+              ) : null}
+            </Box>
             <Box sx={{ display: 'flex', flexDirection: 'column', minWidth: 0, maxWidth: '100%' }}>
               <Typography
                 variant="h4"
@@ -491,7 +504,7 @@ const Greeter: React.FC<any> = ({ history }) => {
                   textOverflow: 'ellipsis'
                 }}
               >
-                Example Banner
+                {appInfo?.name}
               </Typography>
               <Typography
                 variant="body1"
@@ -503,7 +516,7 @@ const Greeter: React.FC<any> = ({ history }) => {
                   textOverflow: 'ellipsis'
                 }}
               >
-                Welcome!
+                {appInfo?.message || (appInfo as any)?.custom_message}
               </Typography>
             </Box>
           </Box>
@@ -544,7 +557,7 @@ const Greeter: React.FC<any> = ({ history }) => {
             }}
           >
             {/* {appName} */}
-            Continue to AppinfoJson 
+            Continue to {appInfo?.name} 
             <br />
             on the {appName}
           </Typography>

--- a/src/pages/Greeter/index.tsx
+++ b/src/pages/Greeter/index.tsx
@@ -91,20 +91,33 @@ const CodeForm = ({ code, setCode, loading, handleSubmitCode, handleResendCode, 
               ),
             }
           }}
-          sx={{ mb: 2 }}
+          sx={{ 
+            mb: 2   
+          }}
         />
         <Button
           variant='contained'
           type='submit'
           disabled={loading || code.length !== 6}
           fullWidth
-          sx={{ mt: 2, borderRadius: theme.shape.borderRadius, textTransform: 'none', py: 1.2 }}
+          sx={{ 
+            mt: 2,
+            borderRadius: theme.shape.borderRadius,
+            textTransform: 'none',
+            py: 1.2
+          }}
         >
           {loading ? <CircularProgress size={24} /> : 'Verify Code'}
         </Button>
       </form>
       <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
-        <Button disabled={loading} onClick={handleResendCode} size="small" color="secondary" sx={{ textTransform: 'none' }}>
+        <Button
+          disabled={loading}
+          onClick={handleResendCode}
+          size="small"
+          color="secondary"
+          sx={{ textTransform: 'none' }}
+        >
           Resend Code
         </Button>
       </Box>
@@ -124,7 +137,9 @@ const PresentationKeyForm = ({ presentationKey, setPresentationKey, loading, han
         variant="outlined"
         fullWidth
         disabled={loading}
-        slotProps={{ input: { ref: presentationKeyFieldRef } }}
+        slotProps={{
+          input: { ref: presentationKeyFieldRef }
+        }}
         sx={{ mb: 2 }}
       />
       <Button
@@ -132,7 +147,12 @@ const PresentationKeyForm = ({ presentationKey, setPresentationKey, loading, han
         type='submit'
         disabled={loading || !presentationKey}
         fullWidth
-        sx={{ mt: 2, borderRadius: theme.shape.borderRadius, textTransform: 'none', py: 1.2 }}
+        sx={{
+          mt: 2,
+          borderRadius: theme.shape.borderRadius,
+          textTransform: 'none',
+          py: 1.2
+        }}
       >
         {loading ? <CircularProgress size={24} /> : 'Continue'}
       </Button>
@@ -157,14 +177,20 @@ const PasswordForm = ({ password, setPassword, confirmPassword, setConfirmPasswo
             ref: passwordFieldRef,
             endAdornment: (
               <InputAdornment position="end">
-                <IconButton aria-label="toggle password visibility" onClick={() => setShowPassword(!showPassword)} edge="end">
+                <IconButton
+                  aria-label="toggle password visibility"
+                  onClick={() => setShowPassword(!showPassword)}
+                  edge="end"
+                >
                   {showPassword ? <VisibilityOff /> : <Visibility />}
                 </IconButton>
               </InputAdornment>
             ),
           }
         }}
-        sx={{ mb: 2 }}
+        sx={{ 
+          mb: 2
+        }}
       />
 
       {accountStatus === 'new-user' && (

--- a/src/pages/Greeter/index.tsx
+++ b/src/pages/Greeter/index.tsx
@@ -691,6 +691,7 @@ useEffect(() => {
               variant='h2'
               fontFamily='Helvetica'
               fontSize='2em'
+              textAlign='center'
               sx={{
                 mb: 1,
                 fontWeight: 'bold',
@@ -703,12 +704,14 @@ useEffect(() => {
             >
               {appInfo?.name ? (
                 <>
-                  Continue to {appInfo.name}
+                  Continue to {appInfo.name} on the 
                   <br />
-                  on the {appName}
+                  {appName}
                 </>
               ) : (
-                <>Explore apps on the {appName}</>
+                <>Explore apps on the 
+                  <br />
+                  {appName}</>
               )}
             </Typography>
           </Box>

--- a/src/pages/Greeter/index.tsx
+++ b/src/pages/Greeter/index.tsx
@@ -1,5 +1,7 @@
 import { useContext, useState, useRef, useCallback, useEffect } from 'react'
 import {
+  AppBar,
+  Toolbar,
   Typography,
   Button,
   TextField,
@@ -248,6 +250,23 @@ const Greeter: React.FC<any> = ({ history }) => {
   const { appVersion, appName, pageLoaded } = useContext(UserContext)
   const theme = useTheme()
 
+  // Banner/new user state
+  const [welcomeUser, setWelcomeUser] = useState(false)
+  const [appInfo, setAppinfo] = useState<any | null>(null)
+
+  // Check sessionStorage for 'appinfo' once on mount
+  useEffect(() => {
+    try {
+      const appinfo = sessionStorage.getItem('appinfo')
+      if (appinfo) {
+        setWelcomeUser(true)
+        setAppinfo(JSON.parse(appinfo))
+      }
+    } catch (err) {
+      // do nothing because it means they are not a new user or storage is unavailable
+    }
+  }, [])
+
   const viewToStepIndex = useWab ? { phone: 0, code: 1, password: 2 } : { presentation: 0, password: 1 }
   const steps = useWab
     ? [
@@ -437,16 +456,71 @@ const Greeter: React.FC<any> = ({ history }) => {
   }
 
   return (
-    <Container maxWidth="sm" sx={{ height: '100vh', display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
-      <Paper 
-        elevation={4} 
-        sx={{ 
-          p: 4, 
-          borderRadius: 2,
-          bgcolor: 'background.paper',
-          boxShadow: theme.shadows[3]
-        }}
-      >
+    <>
+      <AppBar position="fixed" color="primary" elevation={0} sx={{ height: '15vh' }}>
+        <Toolbar disableGutters sx={{ minHeight: '15vh', justifyContent: 'flex-start', px: 2 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'flex-start',
+              width: '100%',
+              gap: 1.5,
+              overflow: 'hidden'
+            }}
+          >
+            <Box
+              sx={{
+                width: 120,
+                height: 120,
+                bgcolor: 'rgba(255,255,255,0.2)',
+                border: '1px solid rgba(255,255,255,0.4)',
+                borderRadius: 1,
+                flex: '0 0 auto'
+              }}
+            />
+            <Box sx={{ display: 'flex', flexDirection: 'column', minWidth: 0, maxWidth: '100%' }}>
+              <Typography
+                variant="h4"
+                sx={{
+                  color: 'inherit',
+                  fontWeight: 600,
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis'
+                }}
+              >
+                Example Banner
+              </Typography>
+              <Typography
+                variant="body1"
+                sx={{
+                  color: 'inherit',
+                  opacity: 0.9,
+                  whiteSpace: 'nowrap',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis'
+                }}
+              >
+                Welcome!
+              </Typography>
+            </Box>
+          </Box>
+        </Toolbar>
+      </AppBar>
+    
+      <Container maxWidth="sm" sx={{ height: '100vh', display: 'flex', flexDirection: 'column', justifyContent: 'center', pt: '15vh' }}>
+        {welcomeUser ? null : (
+          <Paper 
+            elevation={4} 
+            sx={{ 
+              p: 4, 
+              borderRadius: 2,
+              bgcolor: 'background.paper',
+              boxShadow: theme.shadows[3]
+            }}
+          >
         <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', mb: 4 }}>
           <Box sx={{ mb: 2, width: '100px', height: '100px' }}>
             <AppLogo
@@ -469,9 +543,12 @@ const Greeter: React.FC<any> = ({ history }) => {
               WebkitTextFillColor: 'transparent'
             }}
           >
-            {appName}
+            {/* {appName} */}
+            Continue to AppinfoJson 
+            <br />
+            on the {appName}
           </Typography>
-          <Typography 
+          {/* <Typography 
             variant="body1"
             color="text.secondary"
             align="center"
@@ -487,7 +564,7 @@ const Greeter: React.FC<any> = ({ history }) => {
             sx={{ mt: 1 }}
           >
             <i>v{appVersion}</i>
-          </Typography>
+          </Typography> */}
         </Box>
 
         <WalletConfig />
@@ -604,7 +681,9 @@ const Greeter: React.FC<any> = ({ history }) => {
           </a>.
         </Typography>
       </Paper>
-    </Container>
+      )}
+      </Container>
+    </>
   )
 }
 

--- a/src/pages/Greeter/index.tsx
+++ b/src/pages/Greeter/index.tsx
@@ -612,16 +612,37 @@ useEffect(() => {
             ) : (
               // no appInfo: MOVIE SLIDER (scroll-snap, auto-rotate, touch/trackpad friendly)
               <Box
-                sx={{ position: 'relative', height: '100%', display: 'flex', alignItems: 'center', minWidth: 0, zIndex: 0, pr: 6 /* space away from right column */ }}
-                onMouseEnter={() => setPausedBoth(true)}
-                onMouseLeave={() => setPausedBoth(false)}
-                onTouchStart={() => setPausedBoth(true)}
-                onTouchEnd={() => setTimeout(() => setPausedBoth(false), 1000)}
-                onFocusCapture={() => setPausedBoth(true)}
-                onBlurCapture={() => setPausedBoth(false)}
+              sx={{
+                height: '100%',
+                display: 'grid',
+                gridTemplateColumns: 'auto minmax(0,1fr) auto', // [left btn] [rail] [right btn]
+                alignItems: 'center',
+                columnGap: 1,
+                minWidth: 0,
+                zIndex: 0,
+              }}
+              onMouseEnter={() => setPausedBoth?.(true)}
+              onMouseLeave={() => setPausedBoth?.(false)}
+              onTouchStart={() => setPausedBoth?.(true)}
+              onTouchEnd={() => setTimeout(() => setPausedBoth?.(false), 800)}
+              onFocusCapture={() => setPausedBoth?.(true)}
+              onBlurCapture={() => setPausedBoth?.(false)}
+            >
+              {/* LEFT chevron (outside the rail) */}
+              <IconButton
+                size="small"
+                onClick={() => scrollByAmount('left')}
+                sx={{
+                  justifySelf: 'start',
+                  ml: -0.5,                       // optional outward nudge; remove if you want flush
+                  background: 'rgba(0,0,0,0.15)',
+                }}
               >
-                {/* Scrollable rail */}
-                <Box
+                <ChevronLeft />
+              </IconButton>
+
+              {/* Scrollable rail */}
+              <Box
                   ref={railRef}
                   sx={{
                     width: '100%',
@@ -683,23 +704,19 @@ useEffect(() => {
                         </Box>
                       ))}
                 </Box>
-
-                {/* Left/Right nudge buttons (kept inside the slider column; won't cover right button) */}
-                <IconButton
-                  size="small"
-                  onClick={() => scrollByAmount('left')}
-                  sx={{ position: 'absolute', left: 4, zIndex: 1, background: 'rgba(0,0,0,0.15)' }}
-                >
-                  <ChevronLeft />
-                </IconButton>
-                <IconButton
-                  size="small"
-                  onClick={() => scrollByAmount('right')}
-                  sx={{ position: 'absolute', right: 4, zIndex: 1, background: 'rgba(0,0,0,0.15)' }}
-                >
-                  <ChevronRight />
-                </IconButton>
-              </Box>
+              {/* RIGHT chevron (outside the rail) */}
+              <IconButton
+                size="small"
+                onClick={() => scrollByAmount('right')}
+                sx={{
+                  justifySelf: 'end',
+                  mr: -0.5,                       // symmetric outward nudge
+                  background: 'rgba(0,0,0,0.15)',
+                }}
+              >
+                <ChevronRight />
+              </IconButton>
+            </Box>
             )}
 
             {/* RIGHT COLUMN: Clear (X) button when an app is selected */}

--- a/src/pages/Greeter/index.tsx
+++ b/src/pages/Greeter/index.tsx
@@ -334,31 +334,6 @@ useEffect(() => {
     }
   }, [loadRecommendedApps])
 
-  const handleToggleSimulateAppinfo = useCallback(() => {
-    if (devSimulateApp) {
-      try {
-        sessionStorage.removeItem('appinfo')
-        sessionStorage.removeItem('appinfo_handled')
-      } catch {}
-      setAppinfo(null)
-      setWelcomeUser(false)
-      loadRecommendedApps()
-    } else {
-      const sample = {
-        name: 'Pollr',
-        Originator: 'https://pollr.gg',
-        custom_message: 'Please sign up to the metanet to use pollr. A decentralized, secure way to create and vote in polls.'
-      }
-      try {
-        sessionStorage.removeItem('appinfo_handled')
-        sessionStorage.setItem('appinfo', JSON.stringify(sample))
-      } catch {}
-      setAppinfo(sample)
-      setWelcomeUser(true)
-    }
-    setDevSimulateApp(prev => !prev)
-  }, [devSimulateApp, loadRecommendedApps])
-
   // Derive selected app display info (domain, icon) for header
   const selectedApp = useMemo(() => {
     const src = (appInfo as any)?.Originator || (appInfo as any)?.redirected_from
@@ -853,11 +828,6 @@ useEffect(() => {
               </Button>
             </RouterLink>
           </Box>
-          <Box sx={{ justifySelf: 'end', position: 'relative', zIndex: 2 /* ensure above any slider bits */ }}>
-              <Button size="small" variant="outlined" color="secondary" onClick={handleToggleSimulateAppinfo}>
-                {appInfo ? 'Show Explore' : 'Show Welcome'}
-              </Button>
-            </Box>
           <Typography
             variant='caption'
             color='textSecondary'

--- a/src/pages/Greeter/index.tsx
+++ b/src/pages/Greeter/index.tsx
@@ -221,7 +221,7 @@ const Greeter: React.FC<any> = ({ history }) => {
   const [paused, setPaused] = useState(false)
   const pausedRef = useRef(false)
   const setPausedBoth = useCallback((v: boolean) => { pausedRef.current = v; setPaused(v) }, [])
-  const BELT_SPEED_PX_PER_SEC = 150; // belt speed
+  const BELT_SPEED_PX_PER_SEC = 100; // belt speed
   const segWidthRef = useRef(0);
   const rAFRef = useRef<number | null>(null);
   const scrollByAmount = useCallback((dir: 'left' | 'right') => {
@@ -341,7 +341,7 @@ useEffect(() => {
       loadRecommendedApps()
     } else {
       const sample = {
-        name: 'pollr',
+        name: 'Pollr',
         Originator: 'https://pollr.gg',
         custom_message: 'Please sign up to the metanet to use pollr. A decentralized, secure way to create and vote in polls.'
       }
@@ -509,13 +509,13 @@ useEffect(() => {
   }
 
   // Common tile size based on the 15vh banner height (prevents vertical overflow)
-  const tileSize = 'min(110px, calc(15vh - 16px))'
+  const tileSize = 'min(1100px, calc(15vh - 16px))'
 
   return (
     <>
       {/* === APP BAR with auto-rotating movie slider (no overlap with right side) === */}
       <AppBar position="fixed" color="primary" elevation={0} sx={{ height: '15vh' }}>
-        <Toolbar disableGutters sx={{ height: '15vh', px: 2, overflow: 'hidden' }}>
+        <Toolbar disableGutters sx={{ height: '15vh', px: 2, overflow: 'hidden', '--banner-h': '15vh', }}>
           <Box
             sx={{
               display: 'grid',
@@ -555,8 +555,8 @@ useEffect(() => {
                   }}
                 >
                   <MetanetApp
-                    appName={selectedApp.name}
-                    domain={selectedApp.domain || selectedApp.name}
+                    appName={''}
+                    domain={''}
                     iconImageUrl={selectedApp.icon || (selectedApp.domain ? `https://${selectedApp.domain}/favicon.ico` : undefined)}
                     clickable={false}
                   />
@@ -565,18 +565,39 @@ useEffect(() => {
                 {/* Title + message */}
                 <Box sx={{ minWidth: 0 }}>
                   <Typography
-                    variant="h4"
-                    sx={{ color: 'inherit', fontWeight: 600, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', textAlign: 'left' }}
+                  variant="h4"
+                  sx={{
+                    color: 'inherit',
+                    fontWeight: 700,
+                    // min 1.1rem, fluid center = 18% of banner height, max 1.9rem
+                    fontSize: 'clamp(1.1rem, calc(var(--banner-h) * 0.18), 1.9rem)',
+                    lineHeight: 1.2,
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    textAlign: 'left',
+                  }}
                   >
-                    {appInfo?.name}
+                  {appInfo?.name}
                   </Typography>
+
                   {(appInfo?.message || (appInfo as any)?.custom_message) && (
-                    <Typography
-                      variant="body1"
-                      sx={{ color: 'inherit', opacity: 0.9, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', textAlign: 'left' }}
-                    >
-                      {appInfo?.message || (appInfo as any)?.custom_message}
-                    </Typography>
+                  <Typography
+                    variant="body1"
+                    sx={{
+                      color: 'inherit',
+                      opacity: 0.9,
+                      // min 0.9rem, fluid center = 12% of banner height, max 1.2rem
+                      fontSize: 'clamp(0.9rem, calc(var(--banner-h) * 0.12), 1.2rem)',
+                      lineHeight: 1.35,
+                      whiteSpace: 'nowrap',
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      textAlign: 'left',
+                    }}
+                  >
+                    {appInfo?.message || (appInfo as any)?.custom_message}
+                  </Typography>
                   )}
                 </Box>
               </Box>
@@ -593,48 +614,48 @@ useEffect(() => {
               >
                 {/* Scrollable rail */}
                 <Box
-  ref={railRef}
-  sx={{
-    width: '100%',
-    overflowX: 'auto',
-    overflowY: 'hidden',
-    scrollbarWidth: 'none',
-    msOverflowStyle: 'none',
-    '&::-webkit-scrollbar': { display: 'none' },
-    display: 'grid',
-    gridAutoFlow: 'column',
-    gridAutoColumns: tileSize,
-    columnGap: 2,          // 16px
-    alignItems: 'center',
-    px: 4,
-    height: '100%',
-    // IMPORTANT: no scrollSnapType for continuous belt
-  }}
->
-  {recommendedLoading
-    ? Array.from({ length: Math.max(10, beltItems.length) }).map((_, i) => (
-        <Skeleton
-          key={`s-${i}`}
-          variant="rounded"
-          sx={{
-            width: tileSize,
-            height: tileSize,
-            bgcolor: 'rgba(255,255,255,0.15)',
-            borderRadius: 2,
-          }}
-        />
-      ))
-    : beltItems.map((ra, idx) => (
-        <Box key={`${ra.token?.txid ?? ra.metadata?.name}-${idx}`}>
-          <MetanetApp
-            appName={ra.metadata.name}
-            domain={ra.metadata.domain || ra.metadata.name}
-            iconImageUrl={ra.metadata.icon || (ra.metadata.domain ? `https://${ra.metadata.domain}/favicon.ico` : undefined)}
-            clickable={false}
-          />
-        </Box>
-      ))}
-</Box>
+                  ref={railRef}
+                  sx={{
+                    width: '100%',
+                    overflowX: 'auto',
+                    overflowY: 'hidden',
+                    scrollbarWidth: 'none',
+                    msOverflowStyle: 'none',
+                    '&::-webkit-scrollbar': { display: 'none' },
+                    display: 'grid',
+                    gridAutoFlow: 'column',
+                    gridAutoColumns: tileSize,
+                    columnGap: 5,          // 16px
+                    alignItems: 'center',
+                    px: 4,
+                    height: '100%',
+                    // IMPORTANT: no scrollSnapType for continuous belt
+                  }}
+                >
+                  {recommendedLoading
+                    ? Array.from({ length: Math.max(10, beltItems.length) }).map((_, i) => (
+                        <Skeleton
+                          key={`s-${i}`}
+                          variant="rounded"
+                          sx={{
+                            width: tileSize,
+                            height: tileSize,
+                            bgcolor: 'rgba(255,255,255,0.15)',
+                            borderRadius: 2,
+                          }}
+                        />
+                      ))
+                    : beltItems.map((ra, idx) => (
+                        <Box key={`${ra.token?.txid ?? ra.metadata?.name}-${idx}`}>
+                          <MetanetApp
+                            appName={ra.metadata.name}
+                            domain={ra.metadata.domain || ra.metadata.name}
+                            iconImageUrl={ra.metadata.icon || (ra.metadata.domain ? `https://${ra.metadata.domain}/favicon.ico` : undefined)}
+                            clickable={false}
+                          />
+                        </Box>
+                      ))}
+                </Box>
 
                 {/* Left/Right nudge buttons (kept inside the slider column; won't cover right button) */}
                 <IconButton
@@ -654,12 +675,7 @@ useEffect(() => {
               </Box>
             )}
 
-            {/* RIGHT ACTION BUTTON */}
-            <Box sx={{ justifySelf: 'end', position: 'relative', zIndex: 2 /* ensure above any slider bits */ }}>
-              <Button size="small" variant="outlined" color="secondary" onClick={handleToggleSimulateAppinfo}>
-                {appInfo ? 'Show Explore' : 'Show Welcome'}
-              </Button>
-            </Box>
+            
           </Box>
         </Toolbar>
       </AppBar>
@@ -769,7 +785,11 @@ useEffect(() => {
               </Button>
             </RouterLink>
           </Box>
-
+          <Box sx={{ justifySelf: 'end', position: 'relative', zIndex: 2 /* ensure above any slider bits */ }}>
+              <Button size="small" variant="outlined" color="secondary" onClick={handleToggleSimulateAppinfo}>
+                {appInfo ? 'Show Explore' : 'Show Welcome'}
+              </Button>
+            </Box>
           <Typography
             variant='caption'
             color='textSecondary'

--- a/src/utils/appCatalogCache.ts
+++ b/src/utils/appCatalogCache.ts
@@ -1,0 +1,71 @@
+import { AppCatalog as AppCatalogAPI } from 'metanet-apps'
+import type { PublishedApp } from 'metanet-apps/src/types'
+
+// Cache settings aligned with App Catalog page
+export const CACHE_KEY = 'app_catalog_cache_v1'
+export const CACHE_TTL_MS = 15 * 60 * 1000 // 15 minutes
+
+let memoryCache: { ts: number; apps: PublishedApp[] } | null = null
+let inflight: Promise<PublishedApp[]> | null = null
+
+const readLocal = (): { ts: number; apps: PublishedApp[] } | null => {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw)
+    if (!parsed || !Array.isArray(parsed.apps)) return null
+    return { ts: parsed.ts || 0, apps: parsed.apps as PublishedApp[] }
+  } catch {
+    return null
+  }
+}
+
+const writeLocal = (apps: PublishedApp[]) => {
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({ ts: Date.now(), apps }))
+  } catch {
+    // ignore quota errors
+  }
+}
+
+const isStale = (ts: number) => Date.now() - ts > CACHE_TTL_MS
+
+export const invalidateAppCatalogCache = () => {
+  memoryCache = null
+  inflight = null
+}
+
+export async function getAppCatalogApps(options?: { revalidate?: boolean }): Promise<PublishedApp[]> {
+  const revalidate = options?.revalidate === true
+
+  // 1) In-memory cache for current app session
+  if (memoryCache && !revalidate) {
+    return memoryCache.apps
+  }
+
+  // 2) If a network request is in-flight, await it
+  if (inflight) {
+    return inflight
+  }
+
+  // 3) Try localStorage (stale-while-revalidate behavior)
+  const local = readLocal()
+  if (local && !revalidate && !isStale(local.ts)) {
+    memoryCache = local
+    return local.apps
+  }
+
+  // 4) Fetch from network (once), cache in-memory and localStorage
+  inflight = (async () => {
+    const catalog = new AppCatalogAPI({})
+    const apps = await catalog.findApps()
+    memoryCache = { ts: Date.now(), apps }
+    writeLocal(apps)
+    inflight = null
+    return apps
+  })()
+
+  return inflight
+}
+
+export type { PublishedApp }


### PR DESCRIPTION
## Description of Changes
Ensured that the onboarding for new downloads is handled better and users can interact with apps from the catalog. 
The catalog is also now the apps page with a button to go to recents. This was done so that anyone wanting to use metanet apps can do so without having to do an extra click.
App catalog is now also cached
Users who are interested in the banner on login/ or downloaded the app from a web3 app can now be redirected
after login

Provide a brief description of the changes you've made.

## Linked Issues / Tickets

Reference any related issues or tickets, e.g. "Closes #123".

## Testing Procedure

Describe the tests you've added or any testing steps you've taken.

- [ ] I have added new unit tests
- [x] All tests pass locally
- [x] I have tested manually in my local environment

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated `CHANGELOG.md` with my changes
- [ ] I have run `npm run doc` and `npm run lint` one final time before requesting a review
- [ ] I have fixed all linter errors to ensure these changes are compliant with `ts-standard`
- [x] I have run `npm version patch` so that my changes will trigger a new version to be released when they are merged